### PR TITLE
Change default ServerKeyBits to 1024

### DIFF
--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -18,7 +18,7 @@ Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,blowfish-cbc,cast12
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600
-ServerKeyBits 768
+ServerKeyBits 1024
 
 # Logging
 SyslogFacility AUTH


### PR DESCRIPTION
This will set the variable in config file, but existing SSH host keys
are not updated automatically to not surprise the admin with changed
host keys. You can update your SSH host keys by removing existing keys
and issuing command 'dpkg-reconfigure openssh-server'.

Related links:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=727622
