### PR TITLE
By default allow ssh connections from all hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ sshd_allow: []
 sshd_group_allow: []
 sshd_host_allow: []
 
+# Allow connections from all hosts in TCPWrappers by default if list of hosts
+# is not specified
+sshd_tcpwrappers_default: 'ALL'
+
 # By default SSH access from unknown IP addresses is limited and filtered by
 # iptables, you can disable this by changing variable below to 'true'. You will
 # have to enable access in iptables and tcpwrappers from any IP address

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,6 +26,7 @@ dependencies:
 
       - daemon: 'sshd'
         client: '{{ sshd_allow + sshd_group_allow + sshd_host_allow }}'
+        default: '{{ sshd_tcpwrappers_default }}'
         weight: '30'
         filename: 'sshd_dependency_allow'
         comment: 'Allow SSH connections from these hosts (via sshd role dependency)'


### PR DESCRIPTION
Previously TCPWrappers automatically blocked all sshd connections even
though iptables firewall by default allowed them (filtered). Now, by
default connections to sshd are allowed from all hosts, unless a list of
them is specified using 'sshd_*_allow' variables.
