### PR TITLE
Update SSH limit filter in ferm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,20 @@ sshd_host_allow: []
 # is not specified
 sshd_tcpwrappers_default: 'ALL'
 
-# By default SSH access from unknown IP addresses is limited and filtered by
-# iptables, you can disable this by changing variable below to 'true'. You will
-# have to enable access in iptables and tcpwrappers from any IP address
-# separately.
-sshd_unlimited_access: 'false'
+# Enable or disable limited SSH access from all hosts in ip(6)tables. Recent
+# new connections are filtered and when too many new connections are created in
+# specified time window, host is added to the recent blocklist
+sshd_ferm_limit: 'true'
+
+# Length of the time window used by firewall to catch new offenders,
+# by default 1 hour
+sshd_ferm_limit_seconds: '{{ (60 * 60) }}'
+
+# How many new connections to allow in above time window
+sshd_ferm_limit_hits: '3'
+
+# Name of the iptables recent list where offenders will be added
+sshd_ferm_limit_destination: 'badguys'
 
 sshd_Port: 22
 sshd_PermitRootLogin: 'without-password'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,10 +15,13 @@ dependencies:
 
       - type: 'dport_limit'
         dport: [ 'ssh' ]
+        seconds: '{{ sshd_ferm_limit_seconds }}'
+        hits: '{{ sshd_ferm_limit_hits }}'
+        destination: '{{ sshd_ferm_limit_destination }}'
         syn: True
         weight: '30'
         filename: 'sshd_dependency_limit'
-        disabled: '{{ sshd_unlimited_access }}'
+        enabled: '{{ sshd_ferm_limit }}'
 
 
   - role: debops.tcpwrappers


### PR DESCRIPTION
You can now set the name of the recent list which will be used to block
offenders, and lenght of time window used to catch them (by default
1 hour), as well as number of new connections to allow in specified
time window.
