### PR TITLE
Refactor system-wide known_hosts support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,18 @@ sshd_authorized_keys_monkeysphere: '/var/lib/monkeysphere/authorized_keys/%u'
 sshd_authorized_keys_global: '{{ sshd_authorized_keys }}/%u'
 sshd_authorized_keys_user: '%h/.ssh/authorized_keys %h/.ssh/authorized_keys2'
 
-sshd_known_hosts: []
 
+# ---- System-wide host SSH fingerprints ----
+
+# Lists of hosts to scan for SSH fingerprints (global, for a group of hosts and
+# for specific hosts)
+sshd_known_hosts: []
+sshd_group_known_hosts: []
+sshd_host_known_hosts: []
+
+# Command used to scan host fingerprints
+sshd_known_hosts_command: 'ssh-keyscan -H -T 10'
+
+# System-wide file where SSH fingerprints are stored
+sshd_known_hosts_file: '/etc/ssh/ssh_known_hosts'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,17 +8,21 @@
   template: src=etc/ssh/sshd_config.j2 dest=/etc/ssh/sshd_config owner=root group=root mode=0644
   notify: [ 'Test sshd configuration and restart' ]
 
-- name: Create /etc/ssh/ssh_known_hosts.d directory
-  file: path=/etc/ssh/ssh_known_hosts.d state=directory owner=root group=root mode=0755
-  when: sshd_known_hosts is defined and sshd_known_hosts
+- name: Make sure the system-wide known_hosts file exists
+  command: touch {{ sshd_known_hosts_file }}
+  args:
+    creates: '{{ sshd_known_hosts_file }}'
 
-- name: Gather ssh_known_hosts
-  shell: ssh-keyscan {{ item }} > /etc/ssh/ssh_known_hosts.d/{{ item }} creates=/etc/ssh/ssh_known_hosts.d/{{ item }}
-  with_items: sshd_known_hosts
-  when: sshd_known_hosts is defined and sshd_known_hosts
+- name: Get list of already scanned host fingerprints
+  shell: ssh-keygen -f {{ sshd_known_hosts_file }} -F {{ item }} | grep -q '^# Host {{ item }} found'
+  with_items: sshd_known_hosts + sshd_group_known_hosts + sshd_host_known_hosts
+  when: item is defined and item
+  register: sshd_register_known_hosts
+  changed_when: False
+  failed_when: False
 
-- name: Assemble ssh_known_hosts
-  assemble: src=/etc/ssh/ssh_known_hosts.d dest=/etc/ssh/ssh_known_hosts backup=no owner=root group=root mode=0644
-  when: sshd_known_hosts is defined and sshd_known_hosts
-
+- name: Scan SSH fingerprints of specified hosts
+  shell: '{{ sshd_known_hosts_command }} {{ item.item }} >> {{ sshd_known_hosts_file }}'
+  with_items: sshd_register_known_hosts.results
+  when: item is defined and item.rc > 0
 


### PR DESCRIPTION
System wide SSH fingerprint file will be now generated directly instead
of assembled from separate files. This makes the feature more
obfuscated, previously scanned hosts could be inferred from the
filenames of separate parts.

Changes inspired by:
https://juriansluiman.nl/article/151/managing-ssh-known-hosts-with-ansible
