### PR TITLE
Revert old ferm settings related to limit filter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,11 +18,11 @@ sshd_tcpwrappers_default: 'ALL'
 sshd_ferm_limit: 'true'
 
 # Length of the time window used by firewall to catch new offenders,
-# by default 1 hour
-sshd_ferm_limit_seconds: '{{ (60 * 60) }}'
+# by default 5 minutes
+sshd_ferm_limit_seconds: '{{ (60 * 5) }}'
 
 # How many new connections to allow in above time window
-sshd_ferm_limit_hits: '3'
+sshd_ferm_limit_hits: '8'
 
 # Name of the iptables recent list where offenders will be added
 sshd_ferm_limit_destination: 'badguys'


### PR DESCRIPTION
Previous settings (3 hits/1 hour) are good for blocking repeated
offenders with long duration between connections, but very easy to trip
if ssh service is used for ligitimate purpuoses within the cluster.
A better filtering scheme will need to be created.
