### PR TITLE
Use ansible module `copy` instead of shell-command `touch`.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,13 @@
   notify: [ 'Test sshd configuration and restart' ]
 
 - name: Make sure the system-wide known_hosts file exists
-  command: touch {{ sshd_known_hosts_file }}
-  args:
-    creates: '{{ sshd_known_hosts_file }}'
+  copy:
+    force: false
+    dest:  '{{ sshd_known_hosts_file }}'
+    content: ''
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Get list of already scanned host fingerprints
   shell: ssh-keygen -f {{ sshd_known_hosts_file }} -F {{ item }} | grep -q '^# Host {{ item }} found'


### PR DESCRIPTION
This avoids updating the files time-stamp if it already exists.