### PR TITLE
Add separate SSH whitelist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,15 @@
 ---
 
+# Separate list of IP addresses or CIDR networks which should be allowed to
+# access SSH service. This list is not bound to any restrictions if any entries
+# are set.
+sshd_whitelist: []
+sshd_group_whitelist: []
+sshd_host_whitelist: []
+
 # List of IP addresses or CIDR networks to allow access to SSH without
-# restrictions.
+# restrictions. If this list is set, other IP addresses or networks will have
+# limited access.
 # They will be configured in iptables (via ferm) and /etc/hosts.allow (via
 # tcpwrappers).
 sshd_allow: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,12 @@ dependencies:
 
       - type: 'dport_accept'
         dport: [ 'ssh' ]
+        saddr: '{{ sshd_whitelist + sshd_group_whitelist + sshd_host_whitelist }}'
+        weight: '25'
+        filename: 'sshd_dependency_whitelist'
+
+      - type: 'dport_accept'
+        dport: [ 'ssh' ]
         saddr: '{{ sshd_allow + sshd_group_allow + sshd_host_allow }}'
         weight: '30'
         filename: 'sshd_dependency_accept'
@@ -26,6 +32,12 @@ dependencies:
 
   - role: debops.tcpwrappers
     tcpwrappers_allow:
+
+      - daemon: 'sshd'
+        client: '{{ sshd_whitelist + sshd_group_whitelist + sshd_host_whitelist }}'
+        weight: '25'
+        filename: 'sshd_dependency_whitelist'
+        comment: 'Allow SSH connections from these hosts (via sshd role whitelist)'
 
       - daemon: 'sshd'
         client: '{{ sshd_allow + sshd_group_allow + sshd_host_allow }}'


### PR DESCRIPTION
'sshd_*_whitelist' variables provide a separate list fo IP addresses or
networks that are allowed access to SSH service. These lists work
independently of normal 'sshd_*_allow' lists and allow you to give
certain IP addresses unlimited SSH access bypassing the limit filter.