### PR TITLE
* Use template_src lookup plugin to support custom templates and more

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 
+# Packages pertaining to ssh
+
+sshd_packages:
+  - openssh-server
+  - openssh-client
+  - openssh-blacklist
+  - openssh-blacklist-extra
+  - molly-guard
+
 # Separate list of IP addresses or CIDR networks which should be allowed to
 # access SSH service. This list is not bound to any restrictions if any entries
 # are set.
@@ -86,4 +95,4 @@ sshd_config_options_begin: |
 
 # Tips: you can use 'Match LocalPort' to create separate configurations for
 # sshd listening on different ports
-sshd_config_options: False
+sshd_config_options_end: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     pkg: '{{ item }}'
     state: 'present'
     install_recommends: 'no'
-  with_items: '{{ sshd_packages }}'
+  with_items: sshd_packages
 
 - name: Setup /etc/ssh/sshd_config
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,29 @@
 ---
 
 - name: Ensure SSH support is installed
-  apt: pkg={{ item }} state=latest install_recommends=no
-  with_items: [ 'openssh-server', 'openssh-client', 'openssh-blacklist', 'openssh-blacklist-extra', 'molly-guard' ]
+  apt:
+    pkg: '{{ item }}'
+    state: 'present'
+    install_recommends: 'no'
+  with_items: '{{ sshd_packages }}'
 
 - name: Setup /etc/ssh/sshd_config
-  template: src=etc/ssh/sshd_config.j2 dest=/etc/ssh/sshd_config owner=root group=root mode=0644
+  template:
+    src:    "{{ lookup('template_src', 'etc/ssh/sshd_config.j2') }}"
+    dest:   '/etc/ssh/sshd_config'
+    owner:  'root'
+    group:  'root'
+    mode:   '0644'
   notify: [ 'Test sshd configuration and restart' ]
 
 - name: Make sure the system-wide known_hosts file exists
   copy:
-    force: false
-    dest:  '{{ sshd_known_hosts_file }}'
-    content: ''
-    owner: root
-    group: root
-    mode: 0644
+    force:    False
+    dest:     '{{ sshd_known_hosts_file }}'
+    content:  ''
+    owner:    'root'
+    group:    'root'
+    mode:     '0644'
 
 - name: Get list of already scanned host fingerprints
   shell: ssh-keygen -f {{ sshd_known_hosts_file }} -F {{ item }} | grep -q '^# Host {{ item }} found'

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed }}
+# {{ ansible_managed }}
 
 {% if sshd_config_options_begin %}
 # Begin sshd_config_options_begin section (((

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -1,6 +1,6 @@
-# This file is managed by Ansible, all changes will be lost
+{{ ansible_managed }}
 
-{% if sshd_config_options_begin is defined and sshd_config_options_begin %}
+{% if sshd_config_options_begin %}
 # Begin sshd_config_options_begin section (((
 {{ sshd_config_options_begin }}
 # End sshd_config_options_begin section )))
@@ -107,6 +107,6 @@ Match group sftponly
 
         ForceCommand internal-sftp
 
-{% if sshd_config_options is defined and sshd_config_options %}
-{{ sshd_config_options }}
+{% if sshd_config_options_end %}
+{{ sshd_config_options_end }}
 {% endif %}


### PR DESCRIPTION
Changelog:
* Use template_src lookup plugin to support custom templates
* Use ansible_managed variable
* Rewrite tasks to use strict yaml format
* VARIABLE CHANGE: sshd_config_options to sshd_config_options_end
* VARIABLE ADD: sshd_packages
* Update task to install packages to use new variable rather than
  hardcoded values.
* Condensed some logic from 'if fooh is defined and fooh' to just 'if
  fooh' as the Jinja2 documents indicate that testing an undefined
  variable will return false.  This still supports disabling a variable
  by setting it to False.

Identified TODO:
* Update monkeysphere logic
* Fully template rest of config file