### PR TITLE
Limit KexAlgorithms only to known good releases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,7 +90,9 @@ sshd_known_hosts_file: '/etc/ssh/ssh_known_hosts'
 sshd_config_options_begin: |
   # Allowed ciphers
   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc
+  {% if ansible_distribution_release not in [ 'wheezy', 'precise' ] %}
   KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
+  {% endif %}
   MaxAuthTries 3
 
 # Tips: you can use 'Match LocalPort' to create separate configurations for


### PR DESCRIPTION
This variable should be tailored to certain sshd versions, different on
each OS release.