### PR TITLE
Add support to lookup SSH public keys in SSSD

### DIFF
--- a/templates/etc/ssh/authorized_keys_lookup.d/sss.j2
+++ b/templates/etc/ssh/authorized_keys_lookup.d/sss.j2
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# {{ ansible_managed }}
+
+# Lookup SSH public key in SSSD
+
+/usr/bin/sss_ssh_authorizedkeys "${1}"


### PR DESCRIPTION
Can be used by adding ``sss`` to the ``sshd_authorized_keys_lookup_type``. I didn't add the installation of sssd itself to the role, as I handle this separately in [ganto/ansible-freeipa_client](https://github.com/ganto/ansible-freeipa_client). I hope you still like it.

Btw. you really should have a look at sssd yourself. All the fancy client configurations for LDAP that you added in the meantime would be mostly redundant with sssd.