### PR TITLE
Removed sshkeys role dependencies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.2.2
+------
+
+*Unreleased*
+
+- Removed ``debops.sshkeys`` from role dependencies as it is also run from the
+  ``common.yml`` playbook. [ypid]
+
 v0.2.1
 ------
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ More information about `debops.sshd` can be found in the
 ### Role dependencies
 
 - `debops.ferm`
-- `debops.sshkeys`
 - `debops.secret`
 - `debops.apt_preferences`
 - `debops.tcpwrappers`

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [OpenSSH](http://www.openssh.com/) is a secure replacement for `telnet`
 and other remote control programs. It allows you to connect to remote hosts
-over encrypted communication channel and perform variety of tasks. It's
-also primary communication channel used by Ansible.
+over a encrypted communication channel and perform a variety of tasks. It's
+also the main communication channel used by Ansible.
 
 ### Installation
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -65,9 +65,6 @@ Available role tags:
 ``depend::ferm:sshd``
   Run ``debops.ferm`` dependent role in ``debops.sshd`` context.
 
-``depend::sshkeys:sshd``
-  Run ``debops.sshkeys`` dependent role in ``debops.sshd`` context.
-
 ``depend::tcpwrappers:sshd``
   Run ``debops.tcpwrappers`` dependent role in ``debops.sshd`` context.
 

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -19,6 +19,6 @@ ansigenome_info:
   synopsis: |
     [OpenSSH](http://www.openssh.com/) is a secure replacement for `telnet`
     and other remote control programs. It allows you to connect to remote hosts
-    over encrypted communication channel and perform variety of tasks. It's
-    also primary communication channel used by Ansible.
+    over a encrypted communication channel and perform variety of a tasks. It's
+    also the main communication channel used by Ansible.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -62,10 +62,6 @@ dependencies:
         filename: 'sshd_dependency_allow'
         comment: 'Allow SSH connections from these hosts (via sshd role dependency)'
 
-  - role: debops.sshkeys
-    tags: [ 'depend::sshkeys', 'depend::sshkeys:sshd',
-            'depend-of::sshd', 'type::dependency' ]
-
 galaxy_info:
   author: 'Maciej Delmanowski'
   description: 'Configure OpenSSH server'


### PR DESCRIPTION
> Make sure that ssh works when the /etc/ssh/authorized_keys/ directory is not present, or add task to create it if it's not there already.

I checked that. SSH still works without issues.