### PR TITLE
Remove duplicate LoginGraceTime entry

### DIFF
--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -93,7 +93,6 @@ MaxStartups {{ sshd_max_startups }}
 LoginGraceTime {{ sshd_login_grace_time }}
 
 # Authentication:
-LoginGraceTime 120
 PermitRootLogin {{ sshd_permit_root_login }}
 StrictModes yes
 


### PR DESCRIPTION
`LoginGraceTime` is specified twice in the `sshd_config.j2` template. This does not appear to cause a security hazard, as `sshd` uses only the first entry, but it can be confusing when reading the configuration file. This patch removes the duplicate line.