### PR TITLE
return empty list as default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
 
 - name: Scan SSH fingerprints of specified hosts
   shell: '{{ sshd__known_hosts_command }} {{ item.item }} >> {{ sshd__known_hosts_file }}'
-  with_items: '{{ sshd__register_known_hosts.results }}'
+  with_items: '{{ sshd__register_known_hosts.results|d([]) }}'
   when: item is defined and item.rc > 0
   tags: [ 'role::sshd:known_hosts' ]
 


### PR DESCRIPTION
When the registered variable is empty return an empty list as default
to avoid a failure in the loop.

Not doing so results in the following errors:
<pre>
TASK: [debops.sshd | Scan SSH fingerprints of specified hosts] **************** 
fatal: [oc-node01] => with_items expects a list or a set
fatal: [oc-node02] => with_items expects a list or a set
fatal: [oc-node03] => with_items expects a list or a set
</pre>

Tested with ansible 1.9.4