### PR TITLE
Allow to specify additional cryptography related settings.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ v0.2.4
   ``ansible_connection=local`` against a host which does not have ``sshd``
   installed yet. [ypid]
 
+- Added :envvar:`sshd__ciphers_additional`,
+  :envvar:`sshd__kex_algorithms_additional` and :envvar:`sshd__macs_additional`
+  to allow to specify additional cryptography related settings which are also
+  applied in :envvar:`sshd__paranoid` mode.
+  This is needed for the ``debops-contrib.x2go_server`` role.
+  [ypid]
+
 
 v0.2.3
 ------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -334,7 +334,7 @@ sshd__known_hosts_command: 'ssh-keyscan -H -T 10'
 # .. envvar:: sshd__ciphers_map
 #
 # Dict with list of ciphers which should be used by the ``sshd`` server,
-# depending on available version, ordered from newest to oldest. Newer version
+# depending on available version, ordered from strongest to weakest. Newer version
 # supersedes older version.
 sshd__ciphers_map:
 
@@ -347,10 +347,19 @@ sshd__ciphers_map:
   '6.0': [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
 
 
+# .. envvar:: sshd__ciphers_additional
+#
+# List of additional key exchange algorithms which should be used by the
+# ``sshd`` server, depending on available version, depending on available
+# version, ordered from stronger to weaker. Newer version supersedes older
+# version.
+sshd__ciphers_additional: []
+
+
 # .. envvar:: sshd__kex_algorithms_map
 #
 # Dict with list of key exchange algorithms which should be used by the
-# ``sshd`` server, depending on available version, ordered from newest to
+# ``sshd`` server, depending on available version, ordered from strongest to
 # oldest. Newer version supersedes older version.
 sshd__kex_algorithms_map:
 
@@ -363,11 +372,20 @@ sshd__kex_algorithms_map:
   '6.0': [ 'diffie-hellman-group-exchange-sha256' ]
 
 
+# .. envvar:: sshd__kex_algorithms_additional
+#
+# List of additional key exchange algorithms which should be used by the
+# ``sshd`` server, depending on available version, depending on available
+# version, ordered from stronger to weaker. Newer version supersedes older
+# version.
+sshd__kex_algorithms_additional: []
+
+
 # .. envvar:: sshd__macs_map
 #
 # Dict with list of message authentication code algorithms which should be used
-# by the ``sshd`` server, depending on available version, ordered from newest
-# to oldest. Newer version supersedes older version.
+# by the ``sshd`` server, depending on available version, ordered from stronger
+# to weaker. Newer version supersedes older version.
 sshd__macs_map:
 
   # Source: https://wiki.mozilla.org/Security/Guidelines/OpenSSH
@@ -377,6 +395,14 @@ sshd__macs_map:
 
   # Source: https://xivilization.net/~marek/blog/2015/01/12/secure-secure-shell-on-debian-wheezy/
   '6.0': [ 'hmac-sha2-512', 'hmac-sha2-256' , 'hmac-ripemd160' ]
+
+
+# .. envvar:: sshd__macs_additional
+#
+# List of additional message authentication code algorithms to support
+# by the ``sshd`` server, depending on available version, ordered from stronger
+# to weaker. Newer version supersedes older version.
+sshd__macs_additional: []
 
 
 # .. envvar:: sshd__moduli_minimum

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -38,8 +38,9 @@ HostKey /etc/ssh/ssh_host_{{ hostkey }}_key
 {%     endfor %}
 {%   endif %}
 {% endfor %}
+{% set sshd__tpl_ciphers = (sshd__tpl_ciphers + sshd__ciphers_additional) | unique %}
 {% if sshd__tpl_ciphers and sshd__paranoid|bool %}
-Ciphers {{ sshd__tpl_ciphers[0] }}
+Ciphers {{ ([ sshd__tpl_ciphers|first ] + sshd__ciphers_additional) | unique | join(",") }}
 
 {% elif sshd__tpl_ciphers %}
 Ciphers {{ sshd__tpl_ciphers | join(",") }}
@@ -57,8 +58,9 @@ Ciphers {{ sshd__tpl_ciphers | join(",") }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
+{% set sshd__tpl_kex_algorithms = (sshd__tpl_kex_algorithms + sshd__kex_algorithms_additional) | unique %}
 {% if sshd__tpl_kex_algorithms and sshd__paranoid|bool %}
-KexAlgorithms {{ sshd__tpl_kex_algorithms[0] }}
+KexAlgorithms {{ ([ sshd__tpl_kex_algorithms|first ] + sshd__kex_algorithms_additional) | unique | join(",") }}
 
 {% elif sshd__tpl_kex_algorithms %}
 KexAlgorithms {{ sshd__tpl_kex_algorithms | join(",") }}
@@ -76,8 +78,9 @@ KexAlgorithms {{ sshd__tpl_kex_algorithms | join(",") }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
+{% set sshd__tpl_macs = (sshd__tpl_macs + sshd__macs_additional) | unique %}
 {% if sshd__tpl_macs and sshd__paranoid|bool %}
-MACs {{ sshd__tpl_macs[0] }}
+MACs {{ ([ sshd__tpl_macs|first ] + sshd__macs_additional) | unique | join(",") }}
 
 {% elif sshd__tpl_macs %}
 MACs {{ sshd__tpl_macs | join(",") }}


### PR DESCRIPTION
This is needed (or makes it more confident) for the https://github.com/debops-contrib/ansible-x2go_server role.