### PR TITLE
Minor fixes to sshd role

### DIFF
--- a/tasks/authorized_keys_lookup.yml
+++ b/tasks/authorized_keys_lookup.yml
@@ -23,7 +23,7 @@
     ANSIBLE_SSHD_LDAP_BINDPW: '{{ sshd__ldap_bind_pw }}'
   shell: echo -n ${ANSIBLE_SSHD_LDAP_BINDPW} > {{ sshd__ldap_bind_pw_file }} ;
          chmod 0640 {{ sshd__ldap_bind_pw_file }} ;
-         chown root.{{ sshd__authorized_keys_lookup_user }} {{ sshd__ldap_bind_pw_file }}
+         chown root.{{ sshd__authorized_keys_lookup_group }} {{ sshd__ldap_bind_pw_file }}
   args:
     creates: '{{ sshd__ldap_bind_pw_file }}'
   when: sshd__authorized_keys_lookup_type|d() and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
   include: authorized_keys_lookup.yml
   when: sshd__register_version.stdout|d() and
         sshd__register_version.stdout | version_compare('6.2', '>=') and
-        sshd__authorized_keys_lookup|d() and sshd__authorized_keys_lookup|bool
+        sshd__authorized_keys_lookup|bool
   tags: [ 'role::sshd:config' ]
 
 - name: Get list of available host keys

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
   include: authorized_keys_lookup.yml
   when: sshd__register_version.stdout|d() and
         sshd__register_version.stdout | version_compare('6.2', '>=') and
-        sshd__authorized_keys_lookup|d() and sshd__authorized_keys_lookup
+        sshd__authorized_keys_lookup|d() and sshd__authorized_keys_lookup|bool
   tags: [ 'role::sshd:config' ]
 
 - name: Get list of available host keys

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -109,6 +109,7 @@ RSAAuthentication yes
 PubkeyAuthentication yes
 
 {% if sshd__authorized_keys_lookup|d() and
+      sshd__authorized_keys_lookup|bool and
       sshd__register_version.stdout|d() and
       sshd__register_version.stdout | version_compare('6.2', '>=') %}
 AuthorizedKeysCommand /etc/ssh/authorized_keys_lookup

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -108,8 +108,7 @@ StrictModes yes
 RSAAuthentication yes
 PubkeyAuthentication yes
 
-{% if sshd__authorized_keys_lookup|d() and
-      sshd__authorized_keys_lookup|bool and
+{% if sshd__authorized_keys_lookup|bool and
       sshd__register_version.stdout|d() and
       sshd__register_version.stdout | version_compare('6.2', '>=') %}
 AuthorizedKeysCommand /etc/ssh/authorized_keys_lookup


### PR DESCRIPTION
I made a few fixes that should make this role more robust.

Adding the "|bool" in the tests for sshd__authorized_keys_lookup will ensure that it functions correctly even if it gets specified as a string instead of a boolean.