### PR TITLE
Fix dpkg-query failure.

### DIFF
--- a/files/scripts/dpkg-state
+++ b/files/scripts/dpkg-state
@@ -13,7 +13,8 @@ def dpkg_state(package):
 	           '--showformat=${Package} ${Status}\n']
 
 	proc = subprocess.Popen(command, stdout=subprocess.PIPE)
-	for line in proc.stdout:
+	(stdoutdata, _) = proc.communicate()
+	for line in filter(bool, stdoutdata.split('\n')):
 		line = line.decode('ASCII')
 		line = line.rstrip()
 		# "package desired-action error-flags state"
@@ -23,13 +24,9 @@ def dpkg_state(package):
 			break
 	else:
 		state = 'not-installed'
-	proc.stdout.close()
 
-	# Process should either have returned 0,
-	# or been killed because we closed the pipe (stdout).
-	# Otherwise, we had an error.
-	proc.wait()
-	if proc.returncode not in [0, -signal.SIGPIPE]:
+	# dpkg-query returns 0 on success.
+	if proc.returncode != 0:
 		return None
 
 	return state


### PR DESCRIPTION
Looks like dpkg 1.17.27, -signal.SIGPIPE is never returned when we
close() stdout, instead the exit status is 2, most likely because
dpkg-query traps SIGPIPE.

Use Popen.communicate() since we don't expect much output and we get
rid of the deadlock mentioned in
https://docs.python.org/3/library/subprocess.html#popen-objects.