### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,8 @@ Changed
 
 - LDAP lookup script now works with binary and text attributes. [pedroluislopez_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.sshd v0.2.5`_ - 2016-10-10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ Changed
 
 - LDAP lookup script now works with binary and text attributes. [pedroluislopez_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.sshd v0.2.5`_ - 2016-10-10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Changed
 
 - LDAP lookup script now works with binary and text attributes. [pedroluislopez_]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.sshd v0.2.5`_ - 2016-10-10
 ----------------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Configure OpenSSH server'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
                  ["not-installed", "config-files",
                   "unpacked", "half-installed", "half-configured",
                   "triggers-pending", "triggers-awaited", "installed"]
-  check_mode: no
+  check_mode: False
 
 - name: Make sure that OpenSSH configuration directory exists
   file:
@@ -77,7 +77,7 @@
   shell: 'dpkg-query -W -f="\${Version}\n" "openssh-server" | sed -re "s/^.*:([0-9]+\.[0-9]+).*/\1/"'
   register: sshd__register_version
   changed_when: False
-  check_mode: no
+  check_mode: False
   tags: [ 'role::sshd:config' ]
 
 - name: Ensure that Ed25519 host key is present
@@ -100,7 +100,7 @@
   shell: find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key.pub' -exec basename {} .pub \;
   register: sshd__register_host_keys
   changed_when: False
-  check_mode: no
+  check_mode: False
   tags: [ 'role::sshd:config' ]
 
 - name: Setup /etc/ssh/sshd_config
@@ -145,7 +145,7 @@
   shell: awk '$5 < {{ sshd__moduli_minimum }}' /etc/ssh/moduli
   register: sshd__register_moduli
   changed_when: sshd__register_moduli.stdout
-  check_mode: no
+  check_mode: False
 
 - name: Remove DH parameters smaller than the requested size
   shell: awk '$5 >= {{ sshd__moduli_minimum }}' /etc/ssh/moduli > /etc/ssh/moduli.new ;

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
                  ["not-installed", "config-files",
                   "unpacked", "half-installed", "half-configured",
                   "triggers-pending", "triggers-awaited", "installed"]
-  always_run: True
+  check_mode: no
 
 - name: Make sure that OpenSSH configuration directory exists
   file:
@@ -77,7 +77,7 @@
   shell: 'dpkg-query -W -f="\${Version}\n" "openssh-server" | sed -re "s/^.*:([0-9]+\.[0-9]+).*/\1/"'
   register: sshd__register_version
   changed_when: False
-  always_run: True
+  check_mode: no
   tags: [ 'role::sshd:config' ]
 
 - name: Ensure that Ed25519 host key is present
@@ -100,7 +100,7 @@
   shell: find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key.pub' -exec basename {} .pub \;
   register: sshd__register_host_keys
   changed_when: False
-  always_run: True
+  check_mode: no
   tags: [ 'role::sshd:config' ]
 
 - name: Setup /etc/ssh/sshd_config
@@ -145,7 +145,7 @@
   shell: awk '$5 < {{ sshd__moduli_minimum }}' /etc/ssh/moduli
   register: sshd__register_moduli
   changed_when: sshd__register_moduli.stdout
-  always_run: True
+  check_mode: no
 
 - name: Remove DH parameters smaller than the requested size
   shell: awk '$5 >= {{ sshd__moduli_minimum }}' /etc/ssh/moduli > /etc/ssh/moduli.new ;


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.