### PR TITLE
Allow setting AcceptEnv option in variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -208,6 +208,14 @@ sshd__permit_root_login: 'without-password'
 sshd__password_authentication: 'no'
 
                                                                    # ]]]
+# .. envvar:: sshd__accept_env [[[
+#
+# Specifies what environment variables sent by the client will be copied into
+# the session's environment.
+sshd__accept_env:
+  - 'LANG'
+  - 'LC_*'
+                                                                   # ]]]
 # .. envvar:: sshd__x11_forwarding [[[
 #
 # Enable or disable X11 forwarding by the server.

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -159,7 +159,7 @@ TCPKeepAlive yes
 Banner {{ sshd__banner }}
 
 # Allow client to pass locale environment variables
-AcceptEnv LANG LC_*
+AcceptEnv {{ sshd__accept_env | join(" ") }}
 
 Subsystem sftp internal-sftp
 

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -159,7 +159,7 @@ TCPKeepAlive yes
 Banner {{ sshd__banner }}
 
 # Allow client to pass locale environment variables
-AcceptEnv {{ sshd__accept_env | join(" ") }}
+AcceptEnv {{ sshd__accept_env | sort | join(" ") }}
 
 Subsystem sftp internal-sftp
 
@@ -189,4 +189,3 @@ Match {{ entry.match }}
 
 {%   endif %}
 {% endfor %}
-


### PR DESCRIPTION
This change moves previously hardcoded value to role's defaults, providing a way
to override it.
When working with distributed teams, `AcceptEnv` set to "LANG LC_*" may cause
problems.